### PR TITLE
Fix duplicate keys in propTypes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "no-multi-str": 0,
     "quotes": [1, "single"],
     "no-underscore-dangle": 0,
+    "no-dupe-keys": 1,
     "comma-dangle": 0,
     "strict": 0,
     "react/jsx-quotes": 1,

--- a/src/react-cropper.js
+++ b/src/react-cropper.js
@@ -47,7 +47,6 @@ const CropperJS = React.createClass({
       cropstart: React.PropTypes.func,
       cropmove: React.PropTypes.func,
       cropend: React.PropTypes.func,
-      crop: React.PropTypes.func,
       zoom: React.PropTypes.func
    },
 


### PR DESCRIPTION
This was causing fatal errors in a couple of webkit based browsers.